### PR TITLE
header 컴포넌트 작업

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -7,7 +7,7 @@ function App() {
   return (
     <BrowserRouter>
       <Routes>
-        <Route path="/home" element={<Home />} />
+        <Route path="/" element={<Home />} />
         <Route path="/detail" element={<Detail />} />
         <Route path="/modify" element={<Modify />} />
       </Routes>

--- a/src/components/common/Header.jsx
+++ b/src/components/common/Header.jsx
@@ -1,0 +1,23 @@
+import React from "react";
+import { Link } from "react-router-dom";
+import "../../css/Header.css";
+import logo from "../../images/logo.png";
+
+const Header = ({ buttonName, onButtonClick }) => {
+  return (
+    <header className="header">
+      <div className="header-container">
+        <div className="logoContainer">
+          <Link to="/">
+            <img src={logo} className="logo" alt="Logo" />
+          </Link>
+        </div>
+        <button className="headerButton" onClick={onButtonClick}>
+          {buttonName}
+        </button>
+      </div>
+    </header>
+  );
+};
+
+export default Header;

--- a/src/css/Header.css
+++ b/src/css/Header.css
@@ -1,0 +1,43 @@
+.header {
+  width: 100%;
+  position: fixed;
+  top: 0;
+  z-index: 1;
+  display: flex;
+  justify-content: center;
+  background-color: var(--white-color);
+  align-items: center;
+}
+
+.header-container {
+  max-width: 1198px;
+  margin-top: 40px;
+  width: 100%;
+  height: 36px;
+  padding: 0 24px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.logo {
+  width: 152px;
+  height: 32px;
+  padding: 6px 0px 3.59px 0px;
+}
+
+.headerButton {
+  width: 98px;
+  height: 36px;
+  gap: 5px;
+  border-radius: 37px;
+  border: none;
+  background-color: var(--Primary-blue);
+  font: var(--font-pretendard-semibold-15);
+  color: var(--white-color);
+  cursor: pointer;
+}
+
+.headerButton:hover {
+  background-color: #2c30a3;
+}

--- a/src/pages/home/Home.jsx
+++ b/src/pages/home/Home.jsx
@@ -1,7 +1,28 @@
 import React from "react";
+import { useNavigate } from "react-router-dom";
+import Header from "../../components/common/Header";
 
 const Home = () => {
-  return <div>home 화면입니다.</div>;
+  const navigate = useNavigate();
+  const handleButtonClick = () => {
+    navigate("/modify");
+  };
+
+  return (
+    <>
+      <Header buttonName="생성하기" onButtonClick={handleButtonClick} />
+      <div>
+        <br />
+        <br />
+        <br />
+        <br />
+        <br />
+        <a href="/detail">detail - 임시링크</a>
+        <br />
+        <a href="/modify">modify - 임시링크</a>
+      </div>
+    </>
+  );
 };
 
 export default Home;


### PR DESCRIPTION
## #️⃣연관된 이슈
> Closes #4

## 📝작업 내용
> 
1) 헤더 컴포넌트 작업. 
2) Home 페이지에 < 헤더 컴포넌트 /> 배치하고 임시링크 (detail,modify) 구현.
3) Home 페이지 헤더의 생성하기 버튼 클릭시 modify 페이지로 전환되도록 구현. (추후 create 파일이 생성되면 경로 수정하겠습니다.)
4) App.js 파일에서 홈화면 path를 수정했습니다. 

## 💬리뷰 요구사항 (선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
버튼이 [생성하기/돌아가기/내스토어] 3가지 옵션이 필요해서 아래와 같이 props 넣도록 작업했습니다.
<img width="538" alt="image" src="https://github.com/user-attachments/assets/f8c5edf8-bce9-4ebe-9494-ce45431a98c0">
