### PR TITLE
검색기능 (샵카드UI 연결하여 작동하도록 구현)

### DIFF
--- a/src/components/common/Header.jsx
+++ b/src/components/common/Header.jsx
@@ -8,7 +8,7 @@ const Header = ({ buttonName, onButtonClick }) => {
     <header className="header">
       <div className="header-container">
         <div className="logoContainer">
-          <Link to="/">
+          <Link to="/list">
             <img src={logo} className="logo" alt="Logo" />
           </Link>
         </div>

--- a/src/components/home/SearchInput.jsx
+++ b/src/components/home/SearchInput.jsx
@@ -1,30 +1,7 @@
-import React, { useState } from 'react';
 import './SearchInput.css';
 import search from '../../images/icons/search.png';
-import NotFoundResults from './NotFoundResults';
 
-// 샵 리스트 (API로 데이터를 가져올 경우 이 부분을 fetch로 대체)
-const shops = [
-  { id: 1, name: '너구리 직구 상점' },
-  { id: 2, name: '코드잇 상점' },
-  { id: 3, name: '당근 마켓' },
-  { id: 4, name: '스프린트 마켓' },
-];
-
-const SearchInput = () => {
-  const [searchShop, setSearchShop] = useState(''); // 검색어 상태
-  const [visibleShops, setVisibleShops] = useState(shops); // 화면에 보이는 샵 목록 상태
-
-  // 입력된 검색어에 맞는 샵 필터링 함수
-  const handleSearchChange = (e) => {
-    const newShopList = e.target.value;
-    setSearchShop(newShopList);
-
-    // 검색어에 포함된 샵 이름을 필터링
-    const filtered = shops.filter((shop) => shop.name.includes(newShopList));
-    setVisibleShops(filtered); // 필터링된 샵 목록을 업데이트
-  };
-
+const SearchInput = ({ searchShop, onSearchChange }) => {
   return (
     <div>
       <form className="search-form">
@@ -35,19 +12,10 @@ const SearchInput = () => {
             className="search-input"
             placeholder="제목으로 검색해 보세요."
             value={searchShop}
-            onChange={handleSearchChange} // 검색어 변경 시 필터링
+            onChange={(e) => onSearchChange(e.target.value)} // 검색어 변경 시 필터링
           />
         </div>
       </form>
-
-      {visibleShops.length > 0 ? ( // 검색된 샵이 있을 경우
-        visibleShops.map((shop) => <div key={shop.id}>{shop.name}</div>) //각 샵의 이름을 표시
-      ) : (
-        //없을경우 아래 컴포넌트 표시
-        <div>
-          <NotFoundResults />
-        </div>
-      )}
     </div>
   );
 };

--- a/src/pages/RootPage.jsx
+++ b/src/pages/RootPage.jsx
@@ -17,7 +17,7 @@ const RootPage = () => {
   };
 
   const handleButtonClick = () => {
-    navigate('/modify');
+    navigate('/create');
   };
 
   return (

--- a/src/pages/home/CardList.jsx
+++ b/src/pages/home/CardList.jsx
@@ -1,41 +1,40 @@
-import { useEffect, useState } from 'react';
+// import { useEffect, useState } from 'react';
 import ShopCard from './ShopCard';
 import './CardList.css';
 
-const CardList = () => {
-  const [shopCardList, setShopCardList] = useState([]);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState(null);
+const CardList = ({ shops }) => {
+  // const [shopCardList, setShopCardList] = useState([]);
+  // const [loading, setLoading] = useState(true);
+  // const [error, setError] = useState(null);
 
-  useEffect(() => {
-    const fetchData = async () => {
-      try {
-        const response = await fetch(
-          'https://linkshop-api.vercel.app/10-4/linkshops',
-        );
-        if (!response.ok) {
-          throw new Error('네트워크가 응답하지 않습니다.');
-        }
-        const shopData = await response.json();
-        setShopCardList(shopData.list);
-      } catch (err) {
-        setError(err.message);
-      } finally {
-        setLoading(false);
-      }
-    };
+  // useEffect(() => {
+  //   const fetchData = async () => {
+  //     try {
+  //       const response = await fetch(
+  //         'https://linkshop-api.vercel.app/10-4/linkshops',
+  //       );
+  //       if (!response.ok) {
+  //         throw new Error('네트워크가 응답하지 않습니다.');
+  //       }
+  //       const shopData = await response.json();
+  //       setShopCardList(shopData.list);
+  //     } catch (err) {
+  //       setError(err.message);
+  //     } finally {
+  //       setLoading(false);
+  //     }
+  //   };
 
-    fetchData();
-  }, []);
+  //   fetchData();
+  // }, []);
 
-  if (loading) return <div>로딩중</div>;
-
-  if (error) return <div>{error}</div>;
+  // if (loading) return <div>로딩중</div>;
+  // if (error) return <div>{error}</div>;
 
   return (
     <div className="shop-card-list">
       <div>
-        {shopCardList.map((shop) => (
+        {shops.map((shop) => (
           <ShopCard key={shop.id} shopData={shop} />
         ))}
       </div>

--- a/src/pages/home/Home.css
+++ b/src/pages/home/Home.css
@@ -1,0 +1,25 @@
+.loading-container {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  height: 100vh;
+}
+
+.loading-icon {
+  border: 4px solid #f3f3f3;
+  border-top: 4px solid #3e45ec;
+  border-radius: 50%;
+  width: 40px;
+  height: 40px;
+  animation: spin 1s linear infinite;
+  margin: 20px auto;
+}
+
+@keyframes spin {
+  0% {
+    transform: rotate(0deg);
+  }
+  100% {
+    transform: rotate(360deg);
+  }
+}

--- a/src/pages/home/Home.jsx
+++ b/src/pages/home/Home.jsx
@@ -1,20 +1,66 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import Header from '../../components/common/Header';
 import SearchInput from '../../components/home/SearchInput';
 import CardList from './CardList';
-
+import { fetchShopData } from '../../api/homeApi';
+import NotFoundResults from '../../components/home/NotFoundResults';
+import './Home.css';
 
 const Home = () => {
   const navigate = useNavigate();
-  const handleButtonClick = () => {
-    navigate('/modify');
+  const [searchShop, setSearchShop] = useState(''); // 검색어 상태
+  const [shopList, setShopList] = useState([]); // 전체 샵 목록
+  const [visibleShops, setVisibleShops] = useState([]); // 화면에 보이는 샵 목록 상태
+  const [loading, setLoading] = useState(true);
+
+  // 데이터 가져오기
+  useEffect(() => {
+    const fetchShops = async () => {
+      try {
+        const shopData = await fetchShopData();
+        setShopList(shopData);
+        setVisibleShops(shopData);
+      } catch (err) {
+        console.error(err.message);
+      } finally {
+        setLoading(false);
+      }
+    };
+    fetchShops();
+  }, []);
+
+  // 검색어 변경 시 필터링
+  useEffect(() => {
+    const filtered = shopList.filter((shop) =>
+      shop.name.toLowerCase().includes(searchShop.toLowerCase()),
+    );
+    setVisibleShops(filtered);
+  }, [searchShop, shopList]);
+
+  const handleSearchChange = (value) => {
+    setSearchShop(value); // 검색어 업데이트
   };
+
+  const handleButtonClick = () => {
+    navigate('/create');
+  };
+
+  if (loading) {
+    return (
+      <div className="loading-container">
+        <div className="loading-icon"></div>
+      </div>
+    );
+  }
 
   return (
     <>
       <Header buttonName="생성하기" onButtonClick={handleButtonClick} />
-      <SearchInput />
+      <SearchInput
+        searchTerm={searchShop}
+        onSearchChange={handleSearchChange}
+      />
       <div>
         <br />
         <br />
@@ -25,7 +71,11 @@ const Home = () => {
         <br />
         <a href="/modify">modify - 임시링크</a>
         <div>
-          <CardList />
+          {visibleShops.length > 0 ? (
+            <CardList shops={visibleShops} />
+          ) : (
+            <NotFoundResults />
+          )}
         </div>
       </div>
     </>


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #24

## 📝작업 내용

> 검색어 입력시 샵카드 표시되도록 작업했습니다.
기존에는 CardList 컴포넌트가 자체적으로 데이터를 불러오는 방식이기 때문에, 
Home 컴포넌트에서 필터링한 데이터를 CardList에서 사용할 수 없는 상황이었습니다 ㅜㅜ 
CardList에서 데이터를 직접 불러오지 않고, Home 컴포넌트에서 api파일로 부터 받은 데이터를 CardList에 전달하는 방식으로 변경하였습니다. 

> 헤더의 생성하기 버튼 클릭시 생성화면으로 이동되도록 경로 변경했습니다.
> list페이지 새로고침시 "검색결과 없음 화면"이 깜박이며 표시되는 이슈가 있어서 로딩아이콘 표시되도록 구현했습니다.

## 💬리뷰 요구사항(선택)
> 카드리스트 민진님 구현해놓으신 데이터 불러오는 부분을 주석처리했습니다. 
(죄송합니다 ㅜㅜ Home 컴포넌트에서 데이터 관리하는 방법 관련하여 혹시 더 좋은 아이디어가 있다면 알려주세요.)

> 검색어 입력시 모음자음 하나씩 입력할때마다 검색결과 없음과 카드가 번갈아 표시되는데 
좀 정신없지 않나요? 엔터 클릭시 검색결과 표시되어야 하는것은 아닌지 의견부탁드려요~
