### PR TITLE
상점 카드 개선, 정렬 구현 개선

### DIFF
--- a/src/components/home/LikeButton.jsx
+++ b/src/components/home/LikeButton.jsx
@@ -10,7 +10,8 @@ const LikeButton = ({ initialLikes, onLikeChange, linkShopId }) => {
     setCountLikes(initialLikes);
   }, [initialLikes]);
 
-  const handleLikeChange = async () => {
+  const handleLikeChange = async (e) => {
+    e.stopPropagation();
     try {
       if (isLiked) {
         await removeLike(linkShopId);

--- a/src/components/home/ShopInfo.jsx
+++ b/src/components/home/ShopInfo.jsx
@@ -14,9 +14,9 @@ const ShopInfo = ({
   linkShopId,
 }) => {
   return (
-    <div className="shop-card-info">
+    <div className="shop-card-info" onClick={onCardClick}>
       <div className="shop-container">
-        <div className="shop-profile-products" onClick={onCardClick}>
+        <div className="shop-profile-products">
           <div className="shop-profile">
             <img
               src={shop.imageUrl}
@@ -39,7 +39,7 @@ const ShopInfo = ({
           <p className="likes-count">{likes}</p>
         </div>
       </div>
-      <div onClick={onCardClick}>
+      <div>
         <ProductImages products={products} />
       </div>
     </div>

--- a/src/pages/home/Home.jsx
+++ b/src/pages/home/Home.jsx
@@ -57,10 +57,6 @@ const Home = () => {
   const handleSortDataChange = (sortData) => {
     setShopList(sortData);
     setPage(1);
-    const filtered = sortData.filter((shop) =>
-      shop.name.toLowerCase().includes(searchShop.toLowerCase()),
-    );
-    setVisibleShops(filtered.slice(0, itemsPerPage));
   };
 
   if (loading) {


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> ex) #68 

## 📝작업 내용

> 좋아요 버튼을 제외하고 상점 카드를 누르면 상세 페이지로 갈 수 있게 했습니다.
> 불필요한 정렬 관련 코드를 삭제하였습니다.


## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 이런부분이 추가되었는데 이부분 꼭 참고해주세요.
